### PR TITLE
[@mantine/core] Fix `errorProps` position

### DIFF
--- a/src/mantine-core/src/Input/InputWrapper/InputWrapper.tsx
+++ b/src/mantine-core/src/Input/InputWrapper/InputWrapper.tsx
@@ -140,7 +140,7 @@ export const InputWrapper = forwardRef<HTMLDivElement, InputWrapperProps>((props
   const _input = <Fragment key="input">{inputContainer(children)}</Fragment>;
 
   const _error = typeof error !== 'boolean' && error && (
-    <InputError {...errorProps} key="error" {...sharedProps}>
+    <InputError key="error" {...sharedProps} {...errorProps}>
       {error}
     </InputError>
   );


### PR DESCRIPTION
While working with the inputs I realized the error props are overridden by the shared props so I changed their relative position.